### PR TITLE
Allow stopping the local audio player used for cached utterances

### DIFF
--- a/src/CognitiveServices/SpeechSynthesis.ts
+++ b/src/CognitiveServices/SpeechSynthesis.ts
@@ -152,6 +152,17 @@ export class SpeechSynthesizer implements Speech.ISpeechSynthesizer {
         }
     }
 
+    // Stops speaking and local audio player (used for cached utterances).
+    stopAudio(): void {
+        if (this._isPlaying) {
+            if (this._localAudioPlayer && this._localAudioPlayer.currentTime !== 0) {
+                this._localAudioPlayer.pause();
+                this._localAudioPlayer.currentTime = 0;
+            }
+            this.stopSpeaking();
+        }
+    }
+
     private playAudio() {
         if (this._requestQueue.length === 0) {
             return;

--- a/src/SpeechModule.ts
+++ b/src/SpeechModule.ts
@@ -59,6 +59,7 @@ export namespace Speech {
         cacheString(text: string): void;
         speak(text: string, lang: string, onSpeakingStarted: Action, onSpeakingFinished: Action, onEarlySpeakingFinished: Action): void;
         stopSpeaking(): void;
+        stopAudio(): void;
     }
 
     export class SpeechRecognizer {
@@ -354,6 +355,11 @@ export namespace Speech {
                     ss.cancel();
                 }
             }
+        }
+
+        public stopAudio() {
+            // Not using local audio player
+            return;
         }
 
         private playNextTTS(requestContainer: SpeakRequest, iCurrent: number) {


### PR DESCRIPTION
We're using a local audio player to play the cached utterances and the current `stopSpeaking` method doesn't stop it. This PR adds `stopAudio` method which can stop the local audio player.